### PR TITLE
# 🐛 Fix Bug – Muted status on information user

### DIFF
--- a/commands/utility/information.js
+++ b/commands/utility/information.js
@@ -86,7 +86,7 @@ module.exports.main = async(interaction) => {
             .addFields({name: "Identifiant", value: `\`\`\`${userResolved.user.id}\`\`\``, inline:true})
             .addFields({name: "Tag", value: `${userArrFlagsEmbed?userArrFlagsEmbed:"\`\`\`Aucun tag\`\`\`"}`})
             embed.addFields({name: "Rôles", value: `${userRoleArray?userRoleArray:"\`\`\`Aucun rôle\`\`\`"}`})
-            if(userResolved.communicationDisabledUntilTimestamp){
+            if(userResolved.communicationDisabledUntilTimestamp > Date.now()){
                 embed.addFields({name: "Modération status", value: "\`\`\`Muted\`\`\`"})
             }
             embed


### PR DESCRIPTION
# 🐛 Fix Bug – Muted status on information user
## 📌 Référence à l’issue
Fixes #1 

## 🧠 Description du bug
Lors du mute d'un utilisateur, le bot affiche un status "muted", hors lorsque le mute prend fin de manière naturelle (cooldown end), l'utilisateur était toujours noté "muted". Cela était dû au fait que l'on cherchait uniquement si l'utilisateur avait un cooldown de mute, pas s'il était dépassé.

## ✅ Correction apportée
Pour corriger le problème, j'ai ajouter la vérification `if cooldown > date.now()` qui permet d'afficher si ce dernier est mute ou non

## 🔍 Étapes de reproduction (avant correction)
1. Mutez un utilisateur pour 60sec
2. Attendre 60sec
3. Exécutez la commande `information user`
4. L'utilisateur est toujours marqué muted

## ✅ Étapes de validation (après correction)
1. Mutez un utilisateur pour 60sec
2. Attendre 60sec
3. Exécutez la commande `information user`
4. L'utilisateur n'est plus marqué muted

## 🔬 Tests
- [ ] Test unitaire ajouté ou mis à jour
- [x] Testé en local avec plusieurs cas
- [ ] Aucun test automatique cassé (`npm run test`)

## 🧼 Checklist finale
- [x] La PR ne contient **que la correction du bug**
- [x] Les logs de debug (`console.log`) inutiles ont été supprimés
- [x] Le code respecte les conventions (`camelCase`, typage, etc.)
- [x] Cette PR est prête à être relue

> Merci de contribuer à rendre le bot plus stable 🙏  
> Une relecture rapide sera faite par un membre du core team.